### PR TITLE
feat: containers policies support

### DIFF
--- a/endpoint/core/include/privmx/endpoint/core/Factory.hpp
+++ b/endpoint/core/include/privmx/endpoint/core/Factory.hpp
@@ -1,0 +1,36 @@
+/*
+PrivMX Endpoint.
+Copyright © 2024 Simplito sp. z o.o.
+
+This file is part of the PrivMX Platform (https://privmx.dev).
+This software is Licensed under the PrivMX Free License.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _PRIVMXLIB_ENDPOINT_CORE_TYPEDOBJECTFACTORY_HPP_
+#define _PRIVMXLIB_ENDPOINT_CORE_TYPEDOBJECTFACTORY_HPP_
+
+#include <string>
+#include "privmx/utils/Utils.hpp"
+#include "privmx/endpoint/core/ServerTypes.hpp"
+#include "privmx/endpoint/core/Types.hpp"
+#include <Poco/JSON/Object.h>
+
+namespace privmx {
+namespace endpoint {
+namespace core {
+
+class Factory {
+public:
+    static Poco::Dynamic::Var createPolicyServerObject(const ContainerPolicy& policy);
+    static ContainerPolicy parsePolicyServerObject(const Poco::Dynamic::Var serverPolicyObject);
+};
+
+
+}
+}
+}
+
+#endif // _PRIVMXLIB_ENDPOINT_CORE_TYPEDOBJECTFACTORY_HPP_

--- a/endpoint/core/include/privmx/endpoint/core/Factory.hpp
+++ b/endpoint/core/include/privmx/endpoint/core/Factory.hpp
@@ -25,7 +25,7 @@ namespace core {
 class Factory {
 public:
     static Poco::Dynamic::Var createPolicyServerObject(const ContainerPolicy& policy);
-    static ContainerPolicy parsePolicyServerObject(const Poco::Dynamic::Var serverPolicyObject);
+    static ContainerPolicy parsePolicyServerObject(const Poco::Dynamic::Var& serverPolicyObject);
 };
 
 

--- a/endpoint/core/include_pub/privmx/endpoint/core/Types.hpp
+++ b/endpoint/core/include_pub/privmx/endpoint/core/Types.hpp
@@ -81,6 +81,93 @@ struct UserWithPubKey {
     std::string pubKey;
 };
 
+/**
+ * Contains container's policies
+ */
+struct ContainerPolicyWithoutItem {
+    /** 
+     * Determine who can get a container 
+     */
+    std::optional<std::string> get;
+    /** 
+     * Determine who can list containers created by me
+     */
+    std::optional<std::string> listMy;
+    /**
+     * Determine who can list all containers 
+     */
+    std::optional<std::string> listAll;
+    /** 
+     * Determine who can create a container 
+     */
+    std::optional<std::string> create;
+    /** 
+     * Determine who can update a container 
+     */
+    std::optional<std::string> update;
+    /** 
+     * Determine who can delete a container 
+     */
+    std::optional<std::string> delete_;
+    /** 
+     * Determine who can update policy 
+     */
+    std::optional<std::string> updatePolicy;
+    /** 
+     * Determine whether the creator has to be added to the list of managers 
+     */
+    std::optional<std::string> creatorHasToBeManager;
+    /** 
+     * Determine whether the updater can be removed from the list of managers 
+     */
+    std::optional<std::string> updaterCanBeRemovedFromManagers;
+    /** 
+     * Determine whether the owner can be removed from the list of managers 
+     */
+    std::optional<std::string> ownerCanBeRemovedFromManagers;
+    /**
+     * Determine whether the policy can be overwritten in container 
+     */
+    std::optional<std::string> canOverwriteContextPolicy;
+};
+
+/**
+ * Contains container items policies
+ */
+struct ItemPolicy {
+    /** 
+     * Determine who can get an item
+     */
+    std::optional<std::string> get;
+    /** 
+     * Determine who can list items created by me 
+     */
+    std::optional<std::string> listMy;
+    /** 
+     * Determine who can list all items *
+     */
+    std::optional<std::string> listAll;
+    /** 
+     * Determine who can create an item 
+     */
+    std::optional<std::string> create;
+    /**
+     *  Determine who can update an item
+     */
+    std::optional<std::string> update;
+    /** 
+     * Determine who can delete an item 
+     */
+    std::optional<std::string> delete_;    
+};
+
+/**
+ * Contains container and its items policies
+ */
+struct ContainerPolicy : public ContainerPolicyWithoutItem {
+    std::optional<ItemPolicy> item;
+};
+
 }  // namespace core
 }  // namespace endpoint
 }  // namespace privmx

--- a/endpoint/core/include_pub/privmx/endpoint/core/Types.hpp
+++ b/endpoint/core/include_pub/privmx/endpoint/core/Types.hpp
@@ -82,7 +82,7 @@ struct UserWithPubKey {
 };
 
 /**
- * Contains container's policies
+ * Contains container's policies.
  */
 struct ContainerPolicyWithoutItem {
     /** 
@@ -132,7 +132,7 @@ struct ContainerPolicyWithoutItem {
 };
 
 /**
- * Contains container items policies
+ * Contains container items policies.
  */
 struct ItemPolicy {
     /** 
@@ -144,7 +144,7 @@ struct ItemPolicy {
      */
     std::optional<std::string> listMy;
     /** 
-     * Determine who can list all items *
+     * Determine who can list all items
      */
     std::optional<std::string> listAll;
     /** 
@@ -162,7 +162,7 @@ struct ItemPolicy {
 };
 
 /**
- * Contains container and its items policies
+ * Contains container and its items policies.
  */
 struct ContainerPolicy : public ContainerPolicyWithoutItem {
     std::optional<ItemPolicy> item;

--- a/endpoint/core/src/Factory.cpp
+++ b/endpoint/core/src/Factory.cpp
@@ -81,7 +81,7 @@ Poco::Dynamic::Var Factory::createPolicyServerObject(const privmx::endpoint::cor
     return model;
 }
 
-ContainerPolicy Factory::parsePolicyServerObject(const Poco::Dynamic::Var serverPolicyObject) {
+ContainerPolicy Factory::parsePolicyServerObject(const Poco::Dynamic::Var& serverPolicyObject) {
     if (serverPolicyObject.isEmpty()) {
         return {};
     }

--- a/endpoint/core/src/Factory.cpp
+++ b/endpoint/core/src/Factory.cpp
@@ -1,0 +1,115 @@
+/*
+PrivMX Endpoint.
+Copyright © 2024 Simplito sp. z o.o.
+
+This file is part of the PrivMX Platform (https://privmx.dev).
+This software is Licensed under the PrivMX Free License.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "privmx/endpoint/core/Factory.hpp"
+#include "privmx/endpoint/core/Types.hpp"
+#include <Poco/Dynamic/Var.h>
+#include <Poco/JSON/Object.h>
+
+using namespace privmx::endpoint;
+using namespace privmx::endpoint::core;
+
+Poco::Dynamic::Var Factory::createPolicyServerObject(const privmx::endpoint::core::ContainerPolicy& policy) {
+    Poco::JSON::Object::Ptr model = new Poco::JSON::Object();
+    if (policy.get.has_value()) {
+        model->set("get", policy.get.value());
+    }
+    if (policy.listMy.has_value()) {
+        model->set("listMy", policy.listMy.value());
+    }
+    if (policy.listAll.has_value()) {
+        model->set("listAll", policy.listAll.value());
+    }
+    if (policy.create.has_value()) {
+        model->set("create", policy.create.value());
+    }
+    if (policy.update.has_value()) {
+        model->set("update", policy.update.value());
+    }
+    if (policy.delete_.has_value()) {
+        model->set("delete", policy.delete_.value());
+    }
+    if (policy.updatePolicy.has_value()) {
+        model->set("updatePolicy", policy.updatePolicy.value());
+    }
+    if (policy.creatorHasToBeManager.has_value()) {
+        model->set("creatorHasToBeManager", policy.creatorHasToBeManager.value());
+    }
+    if (policy.updaterCanBeRemovedFromManagers.has_value()) {
+        model->set("updaterCanBeRemovedFromManagers", policy.updaterCanBeRemovedFromManagers.value());
+    }
+    if (policy.ownerCanBeRemovedFromManagers.has_value()) {
+        model->set("ownerCanBeRemovedFromManagers", policy.ownerCanBeRemovedFromManagers.value());
+    }
+    if (policy.canOverwriteContextPolicy.has_value()) {
+        model->set("canOverwriteContextPolicy", policy.canOverwriteContextPolicy.value());
+    }
+    if (policy.item.has_value()) {
+        Poco::JSON::Object::Ptr itemModel = new Poco::JSON::Object();
+        auto itemPolicy = policy.item.value();
+
+        if (itemPolicy.get.has_value()) {
+            itemModel->set("get", policy.get.value());
+        }
+        if (itemPolicy.listMy.has_value()) {
+            itemModel->set("listMy", policy.listMy.value());
+        }
+        if (itemPolicy.listAll.has_value()) {
+            itemModel->set("listAll", policy.listAll.value());
+        }
+        if (itemPolicy.create.has_value()) {
+            itemModel->set("create", policy.create.value());
+        }
+        if (itemPolicy.update.has_value()) {
+            itemModel->set("update", policy.update.value());
+        }
+        if (itemPolicy.delete_.has_value()) {
+            itemModel->set("delete", policy.delete_.value());
+        }
+        
+        model->set("item", itemModel);
+    }
+
+    return model;
+}
+
+ContainerPolicy Factory::parsePolicyServerObject(const Poco::Dynamic::Var serverPolicyObject) {
+    if (serverPolicyObject.isEmpty()) {
+        return {};
+    }
+    Poco::JSON::Object::Ptr obj = serverPolicyObject.extract<Poco::JSON::Object::Ptr>();
+    ContainerPolicy result {};
+    result.get = obj->optValue<std::string>("get", std::string());
+    result.listMy = obj->optValue<std::string>("listMy", std::string());
+    result.listAll = obj->optValue<std::string>("listAll", std::string());
+    result.create = obj->optValue<std::string>("create", std::string());
+    result.update = obj->optValue<std::string>("update", std::string());
+    result.delete_ = obj->optValue<std::string>("delete", std::string());
+    result.updatePolicy = obj->optValue<std::string>("updatePolicy", std::string());
+    result.creatorHasToBeManager = obj->optValue<std::string>("creatorHasToBeManager", std::string());
+    result.updaterCanBeRemovedFromManagers = obj->optValue<std::string>("updaterCanBeRemovedFromManagers", std::string());
+    result.ownerCanBeRemovedFromManagers = obj->optValue<std::string>("ownerCanBeRemovedFromManagers", std::string());
+    result.canOverwriteContextPolicy = obj->optValue<std::string>("canOverwriteContextPolicy", std::string());
+
+    if (obj->isObject("item")) {
+        auto itemObj = obj->getObject("item");
+        ItemPolicy itemResult {};
+        itemResult.get = itemObj->optValue<std::string>("get", std::string());
+        itemResult.listMy = itemObj->optValue<std::string>("listMy", std::string());
+        itemResult.listAll = itemObj->optValue<std::string>("listAll", std::string());
+        itemResult.create = itemObj->optValue<std::string>("create", std::string());
+        itemResult.update = itemObj->optValue<std::string>("update", std::string());
+        itemResult.delete_ = itemObj->optValue<std::string>("delete", std::string());
+        result.item = itemResult;
+    }        
+    return result;
+}
+

--- a/endpoint/inbox/include/privmx/endpoint/inbox/InboxApiImpl.hpp
+++ b/endpoint/inbox/include/privmx/endpoint/inbox/InboxApiImpl.hpp
@@ -42,7 +42,7 @@ limitations under the License.
 #include "privmx/endpoint/inbox/Events.hpp"
 #include "privmx/endpoint/inbox/InboxDataProcessorV4.hpp"
 #include "privmx/endpoint/inbox/Factory.hpp"
-
+#include "privmx/endpoint/core/Factory.hpp"
 
 namespace privmx {
 namespace endpoint {
@@ -71,13 +71,15 @@ public:
     std::string createInbox(
         const std::string& contextId, const std::vector<core::UserWithPubKey>& users,
         const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta,
-        const std::optional<inbox::FilesConfig>& filesConfig);
+        const std::optional<inbox::FilesConfig>& filesConfig,
+        const std::optional<core::ContainerPolicy>& policies);
 
     void updateInbox(const std::string& inboxId, const std::vector<core::UserWithPubKey>& users,
                      const std::vector<core::UserWithPubKey>& managers,
                      const core::Buffer& publicMeta, const core::Buffer& privateMeta,
                      const std::optional<inbox::FilesConfig>& filesConfig, const int64_t version, const bool force,
-                     const bool forceGenerateNewKey);
+                     const bool forceGenerateNewKey,
+                     const std::optional<core::ContainerPolicy>& policies);
 
     inbox::Inbox getInbox(const std::string& inboxId);
     core::PagingList<inbox::Inbox> listInboxes(const std::string& contextId, const core::PagingQuery& query);

--- a/endpoint/inbox/include/privmx/endpoint/inbox/ServerTypes.hpp
+++ b/endpoint/inbox/include/privmx/endpoint/inbox/ServerTypes.hpp
@@ -106,6 +106,7 @@ namespace server {
         LIST_FIELD(managers, std::string)
         LIST_FIELD(keys, privmx::endpoint::core::server::KeyEntry)
         INT64_FIELD(version)
+        VAR_FIELD(policy)
     };
 
 
@@ -128,6 +129,7 @@ namespace server {
         OBJECT_FIELD(data, InboxData)
         STRING_FIELD(keyId)
         LIST_FIELD(keys, privmx::endpoint::core::server::KeyEntrySet)
+        VAR_FIELD(policy)
     };
 
     class InboxCreateResult : public utils::TypedObject
@@ -158,6 +160,7 @@ namespace server {
         LIST_FIELD(keys, privmx::endpoint::core::server::KeyEntrySet)
         INT64_FIELD(version)
         BOOL_FIELD(force)
+        VAR_FIELD(policy)
     };
 
     class InboxGetModel : public utils::TypedObject

--- a/endpoint/inbox/include_pub/privmx/endpoint/inbox/InboxApi.hpp
+++ b/endpoint/inbox/include_pub/privmx/endpoint/inbox/InboxApi.hpp
@@ -52,11 +52,13 @@ public:
      * @param publicMeta public (unencrypted) metadata
      * @param privateMeta private (encrypted) metadata
      * @param filesConfig struct to override default file configuration
+     * @param policies Inbox policies
      * @return ID of the created Inbox
      */
     std::string createInbox(const std::string& contextId, const std::vector<core::UserWithPubKey>& users,
                             const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta,
-                            const std::optional<inbox::FilesConfig>& filesConfig);
+                            const std::optional<inbox::FilesConfig>& filesConfig,
+                            const std::optional<core::ContainerPolicy>& policies = std::nullopt);
 
     
     /**
@@ -72,12 +74,14 @@ public:
      * @param version current version of the updated Inbox
      * @param force force update (without checking version)
      * @param forceGenerateNewKey force to regenerate a key for the Inbox
+     * @param policies Inbox policies
      */
     void updateInbox(const std::string& inboxId, const std::vector<core::UserWithPubKey>& users,
                      const std::vector<core::UserWithPubKey>& managers,
                      const core::Buffer& publicMeta, const core::Buffer& privateMeta,
                      const std::optional<inbox::FilesConfig>& filesConfig, const int64_t version, const bool force,
-                     const bool forceGenerateNewKey);
+                     const bool forceGenerateNewKey,
+                     const std::optional<core::ContainerPolicy>& policies = std::nullopt);
 
     /**
      * Gets a single Inbox by given Inbox ID.

--- a/endpoint/inbox/include_pub/privmx/endpoint/inbox/Types.hpp
+++ b/endpoint/inbox/include_pub/privmx/endpoint/inbox/Types.hpp
@@ -119,6 +119,11 @@ struct Inbox {
     std::optional<FilesConfig> filesConfig;
 
     /**
+     * Inbox policies
+     */
+    core::ContainerPolicy policy;
+
+    /**
      * status code of retrieval and decryption of the Inbox
      */
     int64_t statusCode;

--- a/endpoint/inbox/src/InboxApi.cpp
+++ b/endpoint/inbox/src/InboxApi.cpp
@@ -60,11 +60,12 @@ void InboxApi::validateEndpoint() {
 std::string InboxApi::createInbox(
 const std::string& contextId, const std::vector<core::UserWithPubKey>& users,
                             const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta,
-                            const std::optional<inbox::FilesConfig>& filesConfig) {
+                            const std::optional<inbox::FilesConfig>& filesConfig,
+                            const std::optional<core::ContainerPolicy>& policies) {
     validateEndpoint();
     core::Validator::validateId(contextId, "field:contextId ");
     try {
-        return _impl->createInbox(contextId, users, managers, publicMeta, privateMeta, filesConfig);
+        return _impl->createInbox(contextId, users, managers, publicMeta, privateMeta, filesConfig, policies);
     } catch (const privmx::utils::PrivmxException& e) {
         core::ExceptionConverter::rethrowAsCoreException(e);
         throw core::Exception("ExceptionConverter rethrow error");
@@ -76,12 +77,13 @@ void InboxApi::updateInbox(
                      const std::vector<core::UserWithPubKey>& managers,
                      const core::Buffer& publicMeta, const core::Buffer& privateMeta,
                      const std::optional<inbox::FilesConfig>& filesConfig, const int64_t version, const bool force,
-                     const bool forceGenerateNewKey
+                     const bool forceGenerateNewKey,
+                     const std::optional<core::ContainerPolicy>& policies
 ) {
     validateEndpoint();
     core::Validator::validateId(inboxId, "field:inboxId ");
     try {
-        return _impl->updateInbox(inboxId, users, managers, publicMeta, privateMeta, filesConfig, version, force, forceGenerateNewKey);
+        return _impl->updateInbox(inboxId, users, managers, publicMeta, privateMeta, filesConfig, version, force, forceGenerateNewKey, policies);
     } catch (const privmx::utils::PrivmxException& e) {
         core::ExceptionConverter::rethrowAsCoreException(e);
         throw core::Exception("ExceptionConverter rethrow error");

--- a/endpoint/store/include/privmx/endpoint/store/ServerTypes.hpp
+++ b/endpoint/store/include/privmx/endpoint/store/ServerTypes.hpp
@@ -74,6 +74,7 @@ ENDPOINT_SERVER_TYPE(Store)
     INT64_FIELD(lastFileDate)
     INT64_FIELD(files)
     STRING_FIELD(type)
+    VAR_FIELD(policy)
 TYPE_END
 
 ENDPOINT_SERVER_TYPE(StoreCreateModel)
@@ -84,6 +85,7 @@ ENDPOINT_SERVER_TYPE(StoreCreateModel)
     STRING_FIELD(keyId)
     LIST_FIELD(keys, core::server::KeyEntrySet)
     STRING_FIELD(type)
+    VAR_FIELD(policy)
 TYPE_END
 
 ENDPOINT_SERVER_TYPE(StoreUpdateModel)
@@ -95,6 +97,7 @@ ENDPOINT_SERVER_TYPE(StoreUpdateModel)
     LIST_FIELD(keys, core::server::KeyEntrySet)
     INT64_FIELD(version)
     BOOL_FIELD(force)
+    VAR_FIELD(policy)
 TYPE_END
 
 //-----------------------------------------------------

--- a/endpoint/store/include/privmx/endpoint/store/StoreApiImpl.hpp
+++ b/endpoint/store/include/privmx/endpoint/store/StoreApiImpl.hpp
@@ -37,6 +37,7 @@ limitations under the License.
 #include "privmx/endpoint/store/FileMetaEncryptorV4.hpp"
 #include "privmx/endpoint/store/StoreDataEncryptorV4.hpp"
 #include "privmx/endpoint/store/Events.hpp"
+#include "privmx/endpoint/core/Factory.hpp"
 
 namespace privmx {
 namespace endpoint {
@@ -59,8 +60,12 @@ public:
         size_t serverRequestChunkSize
     );
     ~StoreApiImpl();
-    std::string createStore(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta);
-    std::string createStoreEx(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta, const std::string& type);
+    std::string createStore(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers, 
+                const core::Buffer& publicMeta, const core::Buffer& privateMeta,
+                const std::optional<core::ContainerPolicy>& policies);
+    std::string createStoreEx(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers, 
+                const core::Buffer& publicMeta, const core::Buffer& privateMeta, const std::string& type,
+                const std::optional<core::ContainerPolicy>& policies);
     void updateStore(
         const std::string& storeId, 
         const std::vector<core::UserWithPubKey>& users, 
@@ -69,7 +74,8 @@ public:
         const core::Buffer& privateMeta,
         const int64_t version, 
         const bool force, 
-        const bool forceGenerateNewKey
+        const bool forceGenerateNewKey,
+        const std::optional<core::ContainerPolicy>& policies
     );
     void deleteStore(const std::string& storeId);
     Store getStore(const std::string& storeId);
@@ -103,7 +109,9 @@ private:
         std::string hmac;
         int64_t version;
     };
-    std::string _storeCreateEx(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta, const std::string& type);
+    std::string _storeCreateEx(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers, 
+                const core::Buffer& publicMeta, const core::Buffer& privateMeta, const std::string& type,
+                const std::optional<core::ContainerPolicy>& policies);
     Store _storeGetEx(const std::string& storeId, const std::string& type);
     core::PagingList<Store> _storeListEx(const std::string& contextId, const core::PagingQuery& query, const std::string& type);
 

--- a/endpoint/store/include_pub/privmx/endpoint/store/StoreApi.hpp
+++ b/endpoint/store/include_pub/privmx/endpoint/store/StoreApi.hpp
@@ -47,7 +47,8 @@ public:
      * @return created Store ID
      */
     std::string createStore(const std::string& contextId, const std::vector<core::UserWithPubKey>& users,
-                            const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta);
+                            const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta,
+                            const std::optional<core::ContainerPolicy>& policies = std::nullopt);
 
     /**
      * Updates an existing Store.
@@ -64,7 +65,8 @@ public:
     */
     void updateStore(const std::string& storeId, const std::vector<core::UserWithPubKey>& users,
                      const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta, const int64_t version,
-                     const bool force, const bool forceGenerateNewKey);
+                     const bool force, const bool forceGenerateNewKey,
+                     const std::optional<core::ContainerPolicy>& policies = std::nullopt);
 
     /**
      * Deletes a Store by given Store ID.

--- a/endpoint/store/include_pub/privmx/endpoint/store/Types.hpp
+++ b/endpoint/store/include_pub/privmx/endpoint/store/Types.hpp
@@ -137,6 +137,11 @@ struct Store {
     core::Buffer privateMeta;
 
     /**
+     * Store's policies
+     */
+    core::ContainerPolicy policy;
+
+    /**
      * total number of files in the Store
      */
     int64_t filesCount;

--- a/endpoint/store/src/StoreApi.cpp
+++ b/endpoint/store/src/StoreApi.cpp
@@ -56,13 +56,15 @@ void StoreApi::validateEndpoint() {
     if(!_impl) throw NotInitializedException();
 }
 
-std::string StoreApi::createStore(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta) {
+std::string StoreApi::createStore(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers,
+        const core::Buffer& publicMeta, const core::Buffer& privateMeta,
+        const std::optional<core::ContainerPolicy>& policies) {
     validateEndpoint();
     core::Validator::validateId(contextId, "field:contextId ");
     core::Validator::validateClass<std::vector<core::UserWithPubKey>>(users, "field:users ");
     core::Validator::validateClass<std::vector<core::UserWithPubKey>>(managers, "field:managers ");
     try {
-        return _impl->createStore(contextId, users, managers, publicMeta, privateMeta);
+        return _impl->createStore(contextId, users, managers, publicMeta, privateMeta, policies);
     } catch (const privmx::utils::PrivmxException& e) {
         core::ExceptionConverter::rethrowAsCoreException(e);
         throw core::Exception("ExceptionConverter rethrow error");
@@ -77,12 +79,13 @@ void StoreApi::updateStore(
     const core::Buffer& privateMeta,
     const int64_t version, 
     const bool force, 
-    const bool forceGenerateNewKey
+    const bool forceGenerateNewKey,
+    const std::optional<core::ContainerPolicy>& policies
 )
 {
     validateEndpoint();
     try {
-        _impl->updateStore(storeId, users, managers, publicMeta, privateMeta, version, force, forceGenerateNewKey);
+        _impl->updateStore(storeId, users, managers, publicMeta, privateMeta, version, force, forceGenerateNewKey, policies);
     } catch (const privmx::utils::PrivmxException& e) {
         core::ExceptionConverter::rethrowAsCoreException(e);
         throw core::Exception("ExceptionConverter rethrow error");

--- a/endpoint/store/src/StoreApiImpl.cpp
+++ b/endpoint/store/src/StoreApiImpl.cpp
@@ -77,15 +77,21 @@ StoreApiImpl::~StoreApiImpl() {
     _eventMiddleware->removeDisconnectedEventListener(_disconnectedListenerId);
 }
 
-std::string StoreApiImpl::createStore(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta) {
-    return _storeCreateEx(contextId, users, managers, publicMeta, privateMeta, STORE_TYPE_FILTER_FLAG);
+std::string StoreApiImpl::createStore(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers, 
+            const core::Buffer& publicMeta, const core::Buffer& privateMeta,
+            const std::optional<core::ContainerPolicy>& policies) {
+    return _storeCreateEx(contextId, users, managers, publicMeta, privateMeta, STORE_TYPE_FILTER_FLAG, policies);
 }
 
-std::string StoreApiImpl::createStoreEx(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta, const std::string& type) {
-    return _storeCreateEx(contextId, users, managers, publicMeta, privateMeta, type);
+std::string StoreApiImpl::createStoreEx(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers, 
+            const core::Buffer& publicMeta, const core::Buffer& privateMeta,
+            const std::string& type, const std::optional<core::ContainerPolicy>& policies) {
+    return _storeCreateEx(contextId, users, managers, publicMeta, privateMeta, type, policies);
 }
 
-std::string StoreApiImpl::_storeCreateEx(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta, const std::string& type) {
+std::string StoreApiImpl::_storeCreateEx(const std::string& contextId, const std::vector<core::UserWithPubKey>& users, const std::vector<core::UserWithPubKey>& managers, 
+            const core::Buffer& publicMeta, const core::Buffer& privateMeta, const std::string& type,
+            const std::optional<core::ContainerPolicy>& policies) {
     PRIVMX_DEBUG_TIME_START(PlatformStore, _storeCreateEx)
     auto storeKey = _keyProvider->generateKey();
     StoreDataToEncrypt storeDataToEncrypt {
@@ -101,6 +107,9 @@ std::string StoreApiImpl::_storeCreateEx(const std::string& contextId, const std
     storeCreateModel.data(_storeDataEncryptorV4.encrypt(storeDataToEncrypt, _userPrivKey, storeKey.key).asVar());
     if (type.length() > 0) {
         storeCreateModel.type(type);
+    }
+    if (policies.has_value()) {
+        storeCreateModel.policy(privmx::endpoint::core::Factory::createPolicyServerObject(policies.value()));
     }
     auto all_users = core::EndpointUtils::uniqueListUserWithPubKey(users, managers);
     storeCreateModel.keys(_keyProvider->prepareKeysList(all_users, storeKey));
@@ -138,7 +147,8 @@ void StoreApiImpl::updateStore(
         const core::Buffer& privateMeta,
         const int64_t version,
         const bool force,
-        const bool forceGenerateNewKey
+        const bool forceGenerateNewKey,
+        const std::optional<core::ContainerPolicy>& policies
 ) {
     PRIVMX_DEBUG_TIME_START(PlatformStore, storeUpdate)
 
@@ -184,7 +194,9 @@ void StoreApiImpl::updateStore(
     model.managers(managersList);
     model.version(version);
     model.force(force);
-
+    if (policies.has_value()) {
+        model.policy(privmx::endpoint::core::Factory::createPolicyServerObject(policies.value()));
+    }
     StoreDataToEncrypt storeDataToEncrypt {
         .publicMeta = publicMeta,
         .privateMeta = privateMeta,
@@ -705,6 +717,7 @@ Store StoreApiImpl::convertDecryptedStoreDataToStore(const server::Store& storeR
         .version = storeRaw.version(),
         .publicMeta = storeData.publicMeta,
         .privateMeta = storeData.privateMeta,
+        .policy = core::Factory::parsePolicyServerObject(storeRaw.policy()), 
         .filesCount = storeRaw.files(),
         .statusCode = storeData.statusCode
     };

--- a/endpoint/thread/include/privmx/endpoint/thread/ServerTypes.hpp
+++ b/endpoint/thread/include/privmx/endpoint/thread/ServerTypes.hpp
@@ -30,6 +30,7 @@ ENDPOINT_SERVER_TYPE(ThreadCreateModel)
     STRING_FIELD(keyId)
     LIST_FIELD(keys, core::server::KeyEntrySet)
     STRING_FIELD(type)
+    VAR_FIELD(policy)
 TYPE_END
 
 ENDPOINT_SERVER_TYPE(ThreadUpdateModel)
@@ -41,6 +42,7 @@ ENDPOINT_SERVER_TYPE(ThreadUpdateModel)
     LIST_FIELD(keys, core::server::KeyEntrySet)
     INT64_FIELD(version)
     BOOL_FIELD(force)
+    VAR_FIELD(policy)
 TYPE_END
 
 ENDPOINT_SERVER_TYPE(Thread2DataEntry)
@@ -64,6 +66,7 @@ ENDPOINT_SERVER_TYPE(ThreadInfo)
     INT64_FIELD(lastMsgDate)
     INT64_FIELD(messages)
     STRING_FIELD(type)
+    VAR_FIELD(policy)
 TYPE_END
 
 ENDPOINT_SERVER_TYPE(ThreadCreateResult)

--- a/endpoint/thread/include/privmx/endpoint/thread/ThreadApiImpl.hpp
+++ b/endpoint/thread/include/privmx/endpoint/thread/ThreadApiImpl.hpp
@@ -32,6 +32,7 @@ limitations under the License.
 #include "privmx/endpoint/thread/MessageDataEncryptorV4.hpp"
 #include "privmx/endpoint/thread/ThreadDataEncryptorV4.hpp"
 #include "privmx/endpoint/thread/Events.hpp"
+#include "privmx/endpoint/core/Factory.hpp"
 
 namespace privmx {
 namespace endpoint {
@@ -51,13 +52,13 @@ public:
     );
     ~ThreadApiImpl();
     std::string createThread(const std::string& contextId, const std::vector<core::UserWithPubKey>& users,
-                             const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta);
+                             const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta, const std::optional<core::ContainerPolicy>& policies);
     std::string createThreadEx(const std::string& contextId, const std::vector<core::UserWithPubKey>& users,
-                             const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta, const std::string& type);
+                             const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta, const std::string& type, const std::optional<core::ContainerPolicy>& policies);
 
     void updateThread(const std::string& threadId, const std::vector<core::UserWithPubKey>& users,
                       const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta,
-                      const int64_t version, const bool force, const bool forceGenerateNewKey);
+                      const int64_t version, const bool force, const bool forceGenerateNewKey, const std::optional<core::ContainerPolicy>& policies);
     void deleteThread(const std::string& threadId);
 
     Thread getThread(const std::string& threadId);
@@ -84,7 +85,8 @@ private:
         const std::vector<core::UserWithPubKey>& managers,
         const core::Buffer& publicMeta,
         const core::Buffer& privateMeta,
-        const std::string& type
+        const std::string& type,
+        const std::optional<core::ContainerPolicy>& policies
     );
     Thread _getThreadEx(const std::string& threadId, const std::string& type);
     core::PagingList<Thread> _listThreadsEx(const std::string& contextId, const core::PagingQuery& pagingQuery, const std::string& type);

--- a/endpoint/thread/include_pub/privmx/endpoint/thread/ThreadApi.hpp
+++ b/endpoint/thread/include_pub/privmx/endpoint/thread/ThreadApi.hpp
@@ -44,10 +44,12 @@ public:
      * the created Thread
      * @param publicMeta public (unencrypted) metadata
      * @param privateMeta private (encrypted) metadata
+     * @param policies additional container access policies
      * @return ID of the created Thread
      */
     std::string createThread(const std::string& contextId, const std::vector<core::UserWithPubKey>& users,
-                             const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta);
+                             const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, 
+                             const core::Buffer& privateMeta, const std::optional<core::ContainerPolicy>& policies = std::nullopt);
     
     /**
      * Updates an existing Thread.
@@ -61,10 +63,11 @@ public:
      * @param version current version of the updated Thread
      * @param force force update (without checking version)
      * @param forceGenerateNewKey force to regenerate a key for the Thread
+     * @param policies additional container access policies
      */
     void updateThread(const std::string& threadId, const std::vector<core::UserWithPubKey>& users,
                       const std::vector<core::UserWithPubKey>& managers, const core::Buffer& publicMeta, const core::Buffer& privateMeta,
-                      const int64_t version, const bool force, const bool forceGenerateNewKey);
+                      const int64_t version, const bool force, const bool forceGenerateNewKey, const std::optional<core::ContainerPolicy>& policies = std::nullopt);
 
     /**
      * Deletes a Thread by given Thread ID.

--- a/endpoint/thread/include_pub/privmx/endpoint/thread/Types.hpp
+++ b/endpoint/thread/include_pub/privmx/endpoint/thread/Types.hpp
@@ -136,6 +136,11 @@ struct Thread {
     core::Buffer privateMeta;
 
     /**
+     * Thread's policies
+     */
+    core::ContainerPolicy policy;
+
+    /**
      * total number of messages in the Thread
      */
     int64_t messagesCount;

--- a/endpoint/thread/src/ThreadApi.cpp
+++ b/endpoint/thread/src/ThreadApi.cpp
@@ -53,14 +53,15 @@ std::string ThreadApi::createThread(
     const std::vector<core::UserWithPubKey>& users, 
     const std::vector<core::UserWithPubKey>& managers,
     const core::Buffer& publicMeta,
-    const core::Buffer& privateMeta
+    const core::Buffer& privateMeta,
+    const std::optional<core::ContainerPolicy>& policies
 ) {
     validateEndpoint();
     core::Validator::validateId(contextId, "field:contextId ");
     core::Validator::validateClass<std::vector<core::UserWithPubKey>>(users, "field:users ");
     core::Validator::validateClass<std::vector<core::UserWithPubKey>>(managers, "field:managers ");
     try {
-        return _impl->createThread(contextId, users, managers, publicMeta, privateMeta);
+        return _impl->createThread(contextId, users, managers, publicMeta, privateMeta, policies);
     } catch (const privmx::utils::PrivmxException& e) {
         core::ExceptionConverter::rethrowAsCoreException(e);
         throw core::Exception("ExceptionConverter rethrow error");
@@ -75,11 +76,12 @@ void ThreadApi::updateThread(
     const core::Buffer& privateMeta, 
     const int64_t version, 
     const bool force, 
-    const bool forceGenerateNewKey
+    const bool forceGenerateNewKey,
+    const std::optional<core::ContainerPolicy>& policies
 ) {
     validateEndpoint();
     try {
-        _impl->updateThread(threadId, users, managers, publicMeta, privateMeta, version, force, forceGenerateNewKey);
+        _impl->updateThread(threadId, users, managers, publicMeta, privateMeta, version, force, forceGenerateNewKey, policies);
     } catch (const privmx::utils::PrivmxException& e) {
         core::ExceptionConverter::rethrowAsCoreException(e);
         throw core::Exception("ExceptionConverter rethrow error");


### PR DESCRIPTION
Containers create() / update() methods extended by the "policies" parameter letting developer manage the policies of a container. For more details about the policies, go to [PrivMX Bridge Api Docs](https://bridge.privmx.dev/#policy) 