### PR TITLE
fix: Fix C interface compilation error

### DIFF
--- a/endpoint/interface/include/privmx/endpoint/interface/endpoint.h
+++ b/endpoint/interface/include/privmx/endpoint/interface/endpoint.h
@@ -7,43 +7,43 @@
 extern "C" {
 #endif
 
-struct EventQueue;
+typedef struct EventQueue EventQueue;
 
 int privmx_endpoint_newEventQueue(EventQueue** outPtr);
 int privmx_endpoint_freeEventQueue(EventQueue* ptr);
 int privmx_endpoint_execEventQueue(EventQueue* ptr, int method, const pson_value* args, pson_value** res);
 
-struct Connection;
+typedef struct Connection Connection;
 
 int privmx_endpoint_newConnection(Connection** outPtr);
 int privmx_endpoint_freeConnection(Connection* ptr);
 int privmx_endpoint_execConnection(Connection* ptr, int method, const pson_value* args, pson_value** res);
 
-struct BackendRequester;
+typedef struct BackendRequester BackendRequester;
 
 int privmx_endpoint_newBackendRequester(BackendRequester** outPtr);
 int privmx_endpoint_freeBackendRequester(BackendRequester* ptr);
 int privmx_endpoint_execBackendRequester(BackendRequester* ptr, int method, const pson_value* args, pson_value** res);
 
-struct ThreadApi;
+typedef struct ThreadApi ThreadApi;
 
 int privmx_endpoint_newThreadApi(Connection* connectionPtr, ThreadApi** outPtr);
 int privmx_endpoint_freeThreadApi(ThreadApi* ptr);
 int privmx_endpoint_execThreadApi(ThreadApi* ptr, int method, const pson_value* args, pson_value** res);
 
-struct StoreApi;
+typedef struct StoreApi StoreApi;
 
 int privmx_endpoint_newStoreApi(Connection* connectionPtr, StoreApi** outPtr);
 int privmx_endpoint_freeStoreApi(StoreApi* ptr);
 int privmx_endpoint_execStoreApi(StoreApi* ptr, int method, const pson_value* args, pson_value** res);
 
-struct InboxApi;
+typedef struct InboxApi InboxApi;
 
 int privmx_endpoint_newInboxApi(Connection* connectionPtr, ThreadApi* threadApi, StoreApi* storeApi, InboxApi** outPtr);
 int privmx_endpoint_freeInboxApi(InboxApi* ptr);
 int privmx_endpoint_execInboxApi(InboxApi* ptr, int method, const pson_value* args, pson_value** res);
 
-struct CryptoApi;
+typedef struct CryptoApi CryptoApi;
 
 int privmx_endpoint_newCryptoApi(CryptoApi** outPtr);
 int privmx_endpoint_freeCryptoApi(CryptoApi* ptr);


### PR DESCRIPTION
Add typedef for structs as fix compilation error using C compiler.

Refs: #119, PE-87