### PR TITLE
feat: Add timestamp to events

### DIFF
--- a/endpoint/core/include/privmx/endpoint/core/EventBuilder.hpp
+++ b/endpoint/core/include/privmx/endpoint/core/EventBuilder.hpp
@@ -1,0 +1,51 @@
+/*
+PrivMX Endpoint.
+Copyright © 2024 Simplito sp. z o.o.
+
+This file is part of the PrivMX Platform (https://privmx.dev).
+This software is Licensed under the PrivMX Free License.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _PRIVMXLIB_ENDPOINT_CORE_EVENTBUILDER_HPP_
+#define _PRIVMXLIB_ENDPOINT_CORE_EVENTBUILDER_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "privmx/utils/Utils.hpp"
+#include "privmx/endpoint/core/CoreTypes.hpp"
+#include "privmx/endpoint/core/Events.hpp"
+
+namespace privmx {
+namespace endpoint {
+namespace core {
+
+class EventBuilder {
+public:
+    template<typename T, typename D>
+    static std::shared_ptr<T> buildEvent(const std::string& channel, const D& data, const NotificationEvent& notification) {
+        std::shared_ptr<T> event = std::make_shared<T>();
+        event->channel = channel;
+        event->data = data;
+        event->subscriptions = notification.subscriptions;
+        event->timestamp = notification.timestamp;
+        return event;
+    }
+    template<typename T>
+    static std::shared_ptr<T> buildLibEvent() {
+        std::shared_ptr<T> event = std::make_shared<T>();
+        event->timestamp = utils::Utils::getNowTimestamp();
+        return event;
+    }
+};
+
+
+}  // namespace core
+}  // namespace endpoint
+}  // namespace privmx
+
+#endif  //_PRIVMXLIB_ENDPOINT_CORE_EVENTBUILDER_HPP_

--- a/endpoint/core/include/privmx/endpoint/core/VarSerializer.hpp
+++ b/endpoint/core/include/privmx/endpoint/core/VarSerializer.hpp
@@ -44,6 +44,10 @@ public:
     Poco::Dynamic::Var serialize(const std::optional<T>& value);
     template<typename T>
     Poco::Dynamic::Var serialize(const std::map<std::string, T>& value);
+    template<typename B>
+    Poco::JSON::Object::Ptr serializeBase(const B& value, const std::string& type) = delete;
+    template<typename B, typename D>
+    Poco::JSON::Object::Ptr serializeBaseWithData(const D& value, const std::string& type);
 
     const Options& getOptions() const {
         return _options;
@@ -89,6 +93,16 @@ Poco::Dynamic::Var VarSerializer::serialize<Buffer>(const core::Buffer& val);
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<bool>(const bool& val);
+
+template<>
+Poco::JSON::Object::Ptr VarSerializer::serializeBase<Event>(const Event& val, const std::string& type);
+
+template<typename B, typename D>
+inline Poco::JSON::Object::Ptr VarSerializer::serializeBaseWithData(const D& value, const std::string& type) {
+    Poco::JSON::Object::Ptr obj = serializeBase<B>(value, type);
+    obj->set("data", serialize(value.data));
+    return obj;
+}
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<Context>(const Context& val);

--- a/endpoint/core/include_pub/privmx/endpoint/core/Events.hpp
+++ b/endpoint/core/include_pub/privmx/endpoint/core/Events.hpp
@@ -63,6 +63,15 @@ struct Event {
      * List of subscriptions Id for witch it is
      */
     std::vector<std::string> subscriptions;
+
+    /**
+     * Timestamp of the event
+     * 
+     * Represents the point in time when event occurred.
+     * - For events received from Bridge, this value comes from Bridge.
+     * - For events generated in the library, this is a local timestamp.
+    */
+    int64_t timestamp;
 };
 
 /**

--- a/endpoint/core/src/ConnectionImpl.cpp
+++ b/endpoint/core/src/ConnectionImpl.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include "privmx/endpoint/core/Constants.hpp"
 #include "privmx/endpoint/core/EndpointUtils.hpp"
 #include "privmx/endpoint/core/Mapper.hpp"
+#include "privmx/endpoint/core/EventBuilder.hpp"
 
 using namespace privmx::endpoint::core;
 
@@ -56,7 +57,7 @@ void ConnectionImpl::connect(const std::string& userPrivKey, const std::string& 
         std::shared_ptr<EventMiddleware>(new EventMiddleware(EventQueueImpl::getInstance(), _connectionId));
     _handleManager = std::shared_ptr<HandleManager>(new HandleManager());
     _eventMiddleware->addConnectedEventListener([&] {
-        std::shared_ptr<LibConnectedEvent> event(new LibConnectedEvent());
+        auto event = EventBuilder::buildLibEvent<LibConnectedEvent>();
         _eventMiddleware->emitApiEvent(event);
     });
     _contextProvider = std::make_shared<ContextProvider>([&](const std::string& id) {
@@ -65,11 +66,11 @@ void ConnectionImpl::connect(const std::string& userPrivKey, const std::string& 
         return utils::TypedObjectFactory::createObjectFromVar<server::ContextGetResult>(_gateway->request("context.contextGet", model)).context();
     });
     if (_gateway->isConnected()) {
-        std::shared_ptr<LibConnectedEvent> event(new LibConnectedEvent());
+        auto event = EventBuilder::buildLibEvent<LibConnectedEvent>();
         _eventMiddleware->emitApiEvent(event);
     }
     _eventMiddleware->addDisconnectedEventListener([&] {
-        std::shared_ptr<LibDisconnectedEvent> event(new LibDisconnectedEvent());
+        auto event = EventBuilder::buildLibEvent<LibDisconnectedEvent>();
         _eventMiddleware->emitApiEvent(event);
     });
     _gateway->addNotificationEventListener([&, this](const rpc::NotificationEvent& event) {
@@ -110,7 +111,7 @@ void ConnectionImpl::connectPublic(const std::string& solutionId, const std::str
         std::shared_ptr<EventMiddleware>(new EventMiddleware(EventQueueImpl::getInstance(), _connectionId));
     _handleManager = std::shared_ptr<HandleManager>(new HandleManager());
     _eventMiddleware->addConnectedEventListener([&] {
-        std::shared_ptr<LibConnectedEvent> event(new LibConnectedEvent());
+        auto event = EventBuilder::buildLibEvent<LibConnectedEvent>();
         _eventMiddleware->emitApiEvent(event);
     });
     _contextProvider = std::make_shared<ContextProvider>([&](const std::string& id) {
@@ -120,11 +121,11 @@ void ConnectionImpl::connectPublic(const std::string& solutionId, const std::str
         return context;
     });
     if (_gateway->isConnected()) {
-        std::shared_ptr<LibConnectedEvent> event(new LibConnectedEvent());
+        auto event = EventBuilder::buildLibEvent<LibConnectedEvent>();
         _eventMiddleware->emitApiEvent(event);
     }
     _eventMiddleware->addDisconnectedEventListener([&] {
-        std::shared_ptr<LibDisconnectedEvent> event(new LibDisconnectedEvent());
+        auto event = EventBuilder::buildLibEvent<LibDisconnectedEvent>();
         _eventMiddleware->emitApiEvent(event);
     });
     _gateway->addNotificationEventListener([&, this](const rpc::NotificationEvent& event) {
@@ -213,7 +214,7 @@ void ConnectionImpl::disconnect() {
         _gateway->destroy();
     }
     _gateway.reset();
-    std::shared_ptr<LibPlatformDisconnectedEvent> event(new LibPlatformDisconnectedEvent());
+    auto event = EventBuilder::buildLibEvent<LibPlatformDisconnectedEvent>();
     _eventMiddleware->emitApiEvent(event);
 }
 
@@ -301,26 +302,17 @@ void ConnectionImpl::processNotificationEvent(const std::string& type, const cor
     if (type == "contextUserAdded") {
         auto raw = utils::TypedObjectFactory::createObjectFromVar<server::ContextUserEventData>(notification.data);
         auto data = Mapper::mapToContextUserEventData(raw);
-        std::shared_ptr<ContextUserAddedEvent> event(std::make_shared<ContextUserAddedEvent>());
-        event->channel = "context/userAdded";
-        event->data = data;
-        event->subscriptions = notification.subscriptions;
+        auto event = EventBuilder::buildEvent<ContextUserAddedEvent>("context/userAdded", data, notification);
         _eventMiddleware->emitApiEvent(event);
     } else if (type == "contextUserRemoved") {
         auto raw = utils::TypedObjectFactory::createObjectFromVar<server::ContextUserEventData>(notification.data);
         auto data = Mapper::mapToContextUserEventData(raw);
-        std::shared_ptr<ContextUserRemovedEvent> event(std::make_shared<ContextUserRemovedEvent>());
-        event->channel = "context/userRemoved";
-        event->data = data;
-        event->subscriptions = notification.subscriptions;
+        auto event = EventBuilder::buildEvent<ContextUserRemovedEvent>("context/userRemoved", data, notification);
         _eventMiddleware->emitApiEvent(event);
     } else if (type == "contextUserStatusChanged") {
         auto raw = utils::TypedObjectFactory::createObjectFromVar<server::ContextUsersStatusChangeEventData>(notification.data);
         auto data = Mapper::mapToContextUsersStatusChangeData(raw);
-        std::shared_ptr<ContextUsersStatusChangeEvent> event(std::make_shared<ContextUsersStatusChangeEvent>());
-        event->channel = "context/userStatus";
-        event->data = data;
-        event->subscriptions = notification.subscriptions;
+        auto event = EventBuilder::buildEvent<ContextUsersStatusChangeEvent>("context/userStatus", data, notification);
         _eventMiddleware->emitApiEvent(event);
     }
 }

--- a/endpoint/core/src/VarSerializer.cpp
+++ b/endpoint/core/src/VarSerializer.cpp
@@ -76,55 +76,37 @@ Poco::Dynamic::Var VarSerializer::serialize<PagingList<Context>>(const PagingLis
 }
 
 template<>
-Poco::Dynamic::Var VarSerializer::serialize<LibPlatformDisconnectedEvent>(const LibPlatformDisconnectedEvent& val) {
+Poco::JSON::Object::Ptr VarSerializer::serializeBase<Event>(const Event& val, const std::string& type) {
     Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
     if (_options.addType) {
-        obj->set("__type", "core$LibPlatformDisconnectedEvent");
+        obj->set("__type", type);
     }
     obj->set("type", serialize(val.type));
     obj->set("channel", serialize(val.channel));
     obj->set("connectionId", serialize(val.connectionId));
     obj->set("subscriptions", serialize(val.subscriptions));
+    obj->set("timestamp", serialize(val.timestamp));
     return obj;
+}
+
+template<>
+Poco::Dynamic::Var VarSerializer::serialize<LibPlatformDisconnectedEvent>(const LibPlatformDisconnectedEvent& val) {
+    return serializeBase<Event>(val, "core$LibPlatformDisconnectedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<LibConnectedEvent>(const LibConnectedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "core$LibConnectedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    return obj;
+    return serializeBase<Event>(val, "core$LibConnectedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<LibDisconnectedEvent>(const LibDisconnectedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "core$LibDisconnectedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    return obj;
+    return serializeBase<Event>(val, "core$LibDisconnectedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<LibBreakEvent>(const LibBreakEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "core$LibBreakEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    return obj;
+    return serializeBase<Event>(val, "core$LibBreakEvent");
 }
 
 template<>
@@ -153,16 +135,7 @@ Poco::Dynamic::Var VarSerializer::serialize<CollectionChangedEventData>(const Co
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<CollectionChangedEvent>(const CollectionChangedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "core$CollectionChangedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "core$CollectionChangedEvent");
 }
 
 template<>
@@ -200,44 +173,17 @@ Poco::Dynamic::Var VarSerializer::serialize<ContextUsersStatusChangeData>(const 
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<ContextUserAddedEvent>(const ContextUserAddedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "core$ContextUserAddedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "core$ContextUserAddedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<ContextUserRemovedEvent>(const ContextUserRemovedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "core$ContextUserRemovedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "core$ContextUserRemovedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<ContextUsersStatusChangeEvent>(const ContextUsersStatusChangeEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "core$ContextUsersStatusChangeEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "core$ContextUsersStatusChangeEvent");
 }
 
 template<>

--- a/endpoint/event/src/EventApiImpl.cpp
+++ b/endpoint/event/src/EventApiImpl.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include "privmx/endpoint/event/EventException.hpp"
 #include "privmx/endpoint/event/Events.hpp"
 #include "privmx/endpoint/event/Constants.hpp"
+#include "privmx/endpoint/core/EventBuilder.hpp"
 
 using namespace privmx::endpoint;
 using namespace privmx::endpoint::event;
@@ -156,11 +157,8 @@ void EventApiImpl::processNotificationEvent(const std::string& type, const core:
             resultEventData.payload = tmp.data;
             resultEventData.statusCode = tmp.statusCode;
         }
-        std::shared_ptr<privmx::endpoint::event::ContextCustomEvent> event(new privmx::endpoint::event::ContextCustomEvent());
         auto customChannelName = privmx::utils::Utils::split(privmx::utils::Utils::split(channel, "/")[2], "|")[0];
-        event->channel = "context/" + rawEvent.id() + "/" + customChannelName;
-        event->data = resultEventData;
-        event->subscriptions = notification.subscriptions;
+        auto event = core::EventBuilder::buildEvent<privmx::endpoint::event::ContextCustomEvent>("context/" + rawEvent.id() + "/" + customChannelName, resultEventData, notification);
         _eventMiddleware->emitApiEvent(event);
     }
 }

--- a/endpoint/event/src/VarSerializer.cpp
+++ b/endpoint/event/src/VarSerializer.cpp
@@ -19,16 +19,7 @@ using namespace privmx::endpoint::core;
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<event::ContextCustomEvent>(const event::ContextCustomEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "event$ContextCustomEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "event$ContextCustomEvent");
 }
 
 template<>

--- a/endpoint/inbox/src/VarSerializer.cpp
+++ b/endpoint/inbox/src/VarSerializer.cpp
@@ -109,30 +109,12 @@ Poco::Dynamic::Var VarSerializer::serialize<core::PagingList<inbox::InboxEntry>>
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<inbox::InboxCreatedEvent>(const inbox::InboxCreatedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "inbox$InboxCreatedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "inbox$InboxCreatedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<inbox::InboxUpdatedEvent>(const inbox::InboxUpdatedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "inbox$InboxUpdatedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "inbox$InboxUpdatedEvent");
 }
 
 template<>
@@ -148,30 +130,12 @@ Poco::Dynamic::Var VarSerializer::serialize<inbox::InboxDeletedEventData>(const 
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<inbox::InboxDeletedEvent>(const inbox::InboxDeletedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "inbox$InboxDeletedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "inbox$InboxDeletedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<inbox::InboxEntryCreatedEvent>(const inbox::InboxEntryCreatedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "inbox$InboxEntryCreatedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "inbox$InboxEntryCreatedEvent");
 }
 
 
@@ -188,14 +152,5 @@ Poco::Dynamic::Var VarSerializer::serialize<inbox::InboxEntryDeletedEventData>(c
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<inbox::InboxEntryDeletedEvent>(const inbox::InboxEntryDeletedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "inbox$InboxEntryDeletedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "inbox$InboxEntryDeletedEvent");
 }

--- a/endpoint/kvdb/src/VarSerializer.cpp
+++ b/endpoint/kvdb/src/VarSerializer.cpp
@@ -130,101 +130,38 @@ Poco::Dynamic::Var VarSerializer::serialize<kvdb::KvdbDeletedEntryEventData>(
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<kvdb::KvdbCreatedEvent>(const kvdb::KvdbCreatedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "kvdb$KvdbCreatedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "kvdb$KvdbCreatedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<kvdb::KvdbUpdatedEvent>(const kvdb::KvdbUpdatedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "kvdb$KvdbUpdatedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "kvdb$KvdbUpdatedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<kvdb::KvdbDeletedEvent>(const kvdb::KvdbDeletedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "kvdb$KvdbDeletedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "kvdb$KvdbDeletedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<kvdb::KvdbStatsChangedEvent>(const kvdb::KvdbStatsChangedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "kvdb$KvdbStatsChangedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "kvdb$KvdbStatsChangedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<kvdb::KvdbNewEntryEvent>(const kvdb::KvdbNewEntryEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "kvdb$KvdbNewEntryEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "kvdb$KvdbNewEntryEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<kvdb::KvdbEntryUpdatedEvent>(const kvdb::KvdbEntryUpdatedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "kvdb$KvdbEntryUpdatedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "kvdb$KvdbEntryUpdatedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<kvdb::KvdbEntryDeletedEvent>(
     const kvdb::KvdbEntryDeletedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "kvdb$KvdbEntryDeletedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "kvdb$KvdbEntryDeletedEvent");
 }
 
 template<>

--- a/endpoint/store/src/VarSerializer.cpp
+++ b/endpoint/store/src/VarSerializer.cpp
@@ -117,100 +117,37 @@ Poco::Dynamic::Var VarSerializer::serialize<store::StoreFileUpdatedEventData>(
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<store::StoreCreatedEvent>(const store::StoreCreatedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "store$StoreCreatedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "store$StoreCreatedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<store::StoreUpdatedEvent>(const store::StoreUpdatedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "store$StoreUpdatedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "store$StoreUpdatedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<store::StoreDeletedEvent>(const store::StoreDeletedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "store$StoreDeletedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "store$StoreDeletedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<store::StoreStatsChangedEvent>(const store::StoreStatsChangedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "store$StoreStatsChangedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "store$StoreStatsChangedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<store::StoreFileCreatedEvent>(const store::StoreFileCreatedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "store$StoreFileCreatedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "store$StoreFileCreatedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<store::StoreFileUpdatedEvent>(const store::StoreFileUpdatedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "store$StoreFileUpdatedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "store$StoreFileUpdatedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<store::StoreFileDeletedEvent>(const store::StoreFileDeletedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "store$StoreFileDeletedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "store$StoreFileDeletedEvent");
 }
 
 

--- a/endpoint/thread/src/VarSerializer.cpp
+++ b/endpoint/thread/src/VarSerializer.cpp
@@ -89,101 +89,38 @@ Poco::Dynamic::Var VarSerializer::serialize<thread::ThreadStatsEventData>(const 
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<thread::ThreadCreatedEvent>(const thread::ThreadCreatedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "thread$ThreadCreatedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "thread$ThreadCreatedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<thread::ThreadUpdatedEvent>(const thread::ThreadUpdatedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "thread$ThreadUpdatedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "thread$ThreadUpdatedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<thread::ThreadDeletedEvent>(const thread::ThreadDeletedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "thread$ThreadDeletedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "thread$ThreadDeletedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<thread::ThreadNewMessageEvent>(const thread::ThreadNewMessageEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "thread$ThreadNewMessageEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "thread$ThreadNewMessageEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<thread::ThreadMessageUpdatedEvent>(const thread::ThreadMessageUpdatedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "thread$ThreadMessageUpdatedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "thread$ThreadMessageUpdatedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<thread::ThreadMessageDeletedEvent>(
     const thread::ThreadMessageDeletedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "thread$ThreadMessageDeletedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "thread$ThreadMessageDeletedEvent");
 }
 
 template<>
 Poco::Dynamic::Var VarSerializer::serialize<thread::ThreadStatsChangedEvent>(const thread::ThreadStatsChangedEvent& val) {
-    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
-    if (_options.addType) {
-        obj->set("__type", "thread$ThreadStatsChangedEvent");
-    }
-    obj->set("type", serialize(val.type));
-    obj->set("channel", serialize(val.channel));
-    obj->set("connectionId", serialize(val.connectionId));
-    obj->set("subscriptions", serialize(val.subscriptions));
-    obj->set("data", serialize(val.data));
-    return obj;
+    return serializeBaseWithData<Event>(val, "thread$ThreadStatsChangedEvent");
 }
 
 template<>


### PR DESCRIPTION
Add timestamp field to base Event struct.
Add timestamp from Bridge to all events from Bridge. Add local timestamp to events generated in the library. Add base Event serializer and update VarSerializer for all events.

Refs: #266, PE-235