### PR TITLE
Fixed compilation error in StreamApiLowImpl

### DIFF
--- a/endpoint/stream/stream/src/StreamApiLowImpl.cpp
+++ b/endpoint/stream/stream/src/StreamApiLowImpl.cpp
@@ -1071,7 +1071,7 @@ void StreamApiLowImpl::sendStreamKeyRequest(std::shared_ptr<privmx::endpoint::st
         streamRoom.contextId(), 
         core::PagingQuery{
             .skip = 0,
-            .limit = int64_t(usersIds->size()),
+            .limit = static_cast<int64_t>(usersIds->size()),
             .sortOrder = "desc",
             .lastId = std::nullopt,
             .sortBy = std::nullopt,


### PR DESCRIPTION
Explicit cast to int64_t