### PR TITLE
feat(search): expose SQLite transaction control in SearchApi

### DIFF
--- a/endpoint/search/include/privmx/endpoint/search/FullTextSearch.hpp
+++ b/endpoint/search/include/privmx/endpoint/search/FullTextSearch.hpp
@@ -35,6 +35,9 @@ public:
     void updateDocument(const Document& document);
     void deleteDocument(const int64_t documentId);
     core::PagingList<Document> search(const std::string& query, const core::PagingQuery& pagingQuery);
+    void beginTransaction();
+    void commit();
+    void rollback();
     void ensureTableCreated();
     void createTable();
     void close();

--- a/endpoint/search/include/privmx/endpoint/search/SearchApiImpl.hpp
+++ b/endpoint/search/include/privmx/endpoint/search/SearchApiImpl.hpp
@@ -88,6 +88,10 @@ public:
 
     void closeSearchIndex(const int64_t indexHandle);
 
+    void beginTransaction(const int64_t indexHandle);
+    void commit(const int64_t indexHandle);
+    void rollback(const int64_t indexHandle);
+
     int64_t addDocument(const int64_t indexHandle, const std::string& name, const std::string& content);
 
     void updateDocument(const int64_t indexHandle, const Document& document);

--- a/endpoint/search/include/privmx/endpoint/search/varinterface/SearchApiVarInterface.hpp
+++ b/endpoint/search/include/privmx/endpoint/search/varinterface/SearchApiVarInterface.hpp
@@ -39,6 +39,9 @@ public:
         GetDocument = 11,
         ListDocuments = 12,
         SearchDocuments = 13,
+        BeginTransaction = 14,
+        Commit = 15,
+        Rollback = 16,
     };
 
     SearchApiVarInterface(core::Connection connection, store::StoreApi storeApi, kvdb::KvdbApi kvdbApi, const core::VarSerializer& serializer)
@@ -58,7 +61,9 @@ public:
     Poco::Dynamic::Var getDocument(const Poco::Dynamic::Var& args);
     Poco::Dynamic::Var listDocuments(const Poco::Dynamic::Var& args);
     Poco::Dynamic::Var searchDocuments(const Poco::Dynamic::Var& args);
-
+    Poco::Dynamic::Var beginTransaction(const Poco::Dynamic::Var& args);
+    Poco::Dynamic::Var commit(const Poco::Dynamic::Var& args);
+    Poco::Dynamic::Var rollback(const Poco::Dynamic::Var& args);
 
     Poco::Dynamic::Var exec(METHOD method, const Poco::Dynamic::Var& args);
 

--- a/endpoint/search/include_pub/privmx/endpoint/search/SearchApi.hpp
+++ b/endpoint/search/include_pub/privmx/endpoint/search/SearchApi.hpp
@@ -128,6 +128,27 @@ public:
     void closeSearchIndex(const int64_t indexHandle);
 
     /**
+     * Begins a SQLite transaction on the Search Index.
+     *
+     * @param indexHandle Handle of the Index to begin the transaction on
+     */
+    void beginTransaction(const int64_t indexHandle);
+
+    /**
+     * Commits the active transaction on the Search Index.
+     *
+     * @param indexHandle Handle of the Index to commit the transaction on
+     */
+    void commit(const int64_t indexHandle);
+
+    /**
+     * Rolls back the active transaction on the Search Index.
+     *
+     * @param indexHandle Handle of the Index to roll back the transaction on
+     */
+    void rollback(const int64_t indexHandle);
+
+    /**
      * Adds a new document to the Search Index.
      *
      * @param indexHandle Handle of the Index to add the document to

--- a/endpoint/search/include_pub/privmx/endpoint/search/SearchException.hpp
+++ b/endpoint/search/include_pub/privmx/endpoint/search/SearchException.hpp
@@ -57,6 +57,10 @@ DECLARE_ENDPOINT_EXCEPTION(EndpointSearchException, SelectPrepareException, "Err
 DECLARE_ENDPOINT_EXCEPTION(EndpointSearchException, QueryPrepareException, "Error preparing query", 0x0208)
 DECLARE_ENDPOINT_EXCEPTION(EndpointSearchException, TableCreationException, "Error creating table", 0x0209)
 
+DECLARE_ENDPOINT_EXCEPTION(EndpointSearchException, TransactionBeginException, "Error beginning transaction", 0x0301)
+DECLARE_ENDPOINT_EXCEPTION(EndpointSearchException, TransactionCommitException, "Error committing transaction", 0x0302)
+DECLARE_ENDPOINT_EXCEPTION(EndpointSearchException, TransactionRollbackException, "Error rolling back transaction", 0x0303)
+
 } // search
 } // endpoint
 } // privmx

--- a/endpoint/search/src/FullTextSearch.cpp
+++ b/endpoint/search/src/FullTextSearch.cpp
@@ -217,6 +217,33 @@ core::PagingList<Document> FullTextSearch::search(const std::string& query, cons
     return {getCount(query), results};
 }
 
+void FullTextSearch::beginTransaction() {
+    char* err = nullptr;
+    if (sqlite3_exec(_db.get(), "BEGIN TRANSACTION;", nullptr, nullptr, &err) != SQLITE_OK) {
+        std::string msg = err;
+        sqlite3_free(err);
+        throw TransactionBeginException(msg);
+    }
+}
+
+void FullTextSearch::commit() {
+    char* err = nullptr;
+    if (sqlite3_exec(_db.get(), "COMMIT;", nullptr, nullptr, &err) != SQLITE_OK) {
+        std::string msg = err;
+        sqlite3_free(err);
+        throw TransactionCommitException(msg);
+    }
+}
+
+void FullTextSearch::rollback() {
+    char* err = nullptr;
+    if (sqlite3_exec(_db.get(), "ROLLBACK;", nullptr, nullptr, &err) != SQLITE_OK) {
+        std::string msg = err;
+        sqlite3_free(err);
+        throw TransactionRollbackException(msg);
+    }
+}
+
 void FullTextSearch::ensureTableCreated() {
     try {
         createTable();

--- a/endpoint/search/src/SearchApi.cpp
+++ b/endpoint/search/src/SearchApi.cpp
@@ -146,6 +146,36 @@ void SearchApi::closeSearchIndex(const int64_t indexHandle) {
     }
 }
 
+void SearchApi::beginTransaction(const int64_t indexHandle) {
+    auto impl = getImpl();
+    try {
+        impl->beginTransaction(indexHandle);
+    } catch (const privmx::utils::PrivmxException& e) {
+        core::ExceptionConverter::rethrowAsCoreException(e);
+        throw core::Exception("ExceptionConverter rethrow error");
+    }
+}
+
+void SearchApi::commit(const int64_t indexHandle) {
+    auto impl = getImpl();
+    try {
+        impl->commit(indexHandle);
+    } catch (const privmx::utils::PrivmxException& e) {
+        core::ExceptionConverter::rethrowAsCoreException(e);
+        throw core::Exception("ExceptionConverter rethrow error");
+    }
+}
+
+void SearchApi::rollback(const int64_t indexHandle) {
+    auto impl = getImpl();
+    try {
+        impl->rollback(indexHandle);
+    } catch (const privmx::utils::PrivmxException& e) {
+        core::ExceptionConverter::rethrowAsCoreException(e);
+        throw core::Exception("ExceptionConverter rethrow error");
+    }
+}
+
 int64_t SearchApi::addDocument(const int64_t indexHandle, const std::string& name, const std::string& content) {
     auto impl = getImpl();
     try {

--- a/endpoint/search/src/SearchApiImpl.cpp
+++ b/endpoint/search/src/SearchApiImpl.cpp
@@ -109,6 +109,21 @@ void SearchApiImpl::closeSearchIndex(const int64_t indexHandle) {
     _fts.remove(indexHandle);
 }
 
+void SearchApiImpl::beginTransaction(const int64_t indexHandle) {
+    auto fts = _fts.get(indexHandle);
+    fts->beginTransaction();
+}
+
+void SearchApiImpl::commit(const int64_t indexHandle) {
+    auto fts = _fts.get(indexHandle);
+    fts->commit();
+}
+
+void SearchApiImpl::rollback(const int64_t indexHandle) {
+    auto fts = _fts.get(indexHandle);
+    fts->rollback();
+}
+
 int64_t SearchApiImpl::addDocument(const int64_t indexHandle, const std::string& name, const std::string& content) {
     auto fts = _fts.get(indexHandle);
     return fts->addDocument(name, content);

--- a/endpoint/search/src/varinterface/SearchApiVarInterface.cpp
+++ b/endpoint/search/src/varinterface/SearchApiVarInterface.cpp
@@ -33,7 +33,10 @@ std::map<SearchApiVarInterface::METHOD, Poco::Dynamic::Var (SearchApiVarInterfac
                                         {DeleteDocument, &SearchApiVarInterface::deleteDocument},
                                         {GetDocument, &SearchApiVarInterface::getDocument},
                                         {ListDocuments, &SearchApiVarInterface::listDocuments},
-                                        {SearchDocuments, &SearchApiVarInterface::searchDocuments}};
+                                        {SearchDocuments, &SearchApiVarInterface::searchDocuments},
+                                        {BeginTransaction, &SearchApiVarInterface::beginTransaction},
+                                        {Commit, &SearchApiVarInterface::commit},
+                                        {Rollback, &SearchApiVarInterface::rollback}};
 
 Poco::Dynamic::Var SearchApiVarInterface::create(const Poco::Dynamic::Var& args) {
     core::VarInterfaceUtil::validateAndExtractArray(args, 0);
@@ -153,6 +156,27 @@ Poco::Dynamic::Var SearchApiVarInterface::searchDocuments(const Poco::Dynamic::V
     auto pagingQuery = _deserializer.deserialize<core::PagingQuery>(argsArr->get(2), "pagingQuery");
     auto result = _searchApi.searchDocuments(indexHandle, searchQuery, pagingQuery);
     return _serializer.serialize(result);
+}
+
+Poco::Dynamic::Var SearchApiVarInterface::beginTransaction(const Poco::Dynamic::Var& args) {
+    auto argsArr = core::VarInterfaceUtil::validateAndExtractArray(args, 1);
+    auto indexHandle = _deserializer.deserialize<int64_t>(argsArr->get(0), "indexHandle");
+    _searchApi.beginTransaction(indexHandle);
+    return {};
+}
+
+Poco::Dynamic::Var SearchApiVarInterface::commit(const Poco::Dynamic::Var& args) {
+    auto argsArr = core::VarInterfaceUtil::validateAndExtractArray(args, 1);
+    auto indexHandle = _deserializer.deserialize<int64_t>(argsArr->get(0), "indexHandle");
+    _searchApi.commit(indexHandle);
+    return {};
+}
+
+Poco::Dynamic::Var SearchApiVarInterface::rollback(const Poco::Dynamic::Var& args) {
+    auto argsArr = core::VarInterfaceUtil::validateAndExtractArray(args, 1);
+    auto indexHandle = _deserializer.deserialize<int64_t>(argsArr->get(0), "indexHandle");
+    _searchApi.rollback(indexHandle);
+    return {};
 }
 
 Poco::Dynamic::Var SearchApiVarInterface::exec(METHOD method, const Poco::Dynamic::Var& args) {


### PR DESCRIPTION
## Summary

- Adds `beginTransaction`, `commit`, and `rollback` to `FullTextSearch`,
  `SearchApiImpl`, `SearchApi`, and `SearchApiVarInterface` (methods 14–16).
- Adds three new exceptions: `TransactionBeginException` (0x0301),
  `TransactionCommitException` (0x0302), `TransactionRollbackException` (0x0303).

## Motivation

Without explicit transaction control, each `addDocument` / `updateDocument` /
`deleteDocument` call runs in its own implicit SQLite transaction. When
indexing many documents at once this creates significant overhead — SQLite
flushes to disk after every statement. Exposing `BEGIN` / `COMMIT` / `ROLLBACK`
lets callers wrap bulk mutations in a single transaction, reducing I/O and
dramatically improving throughput for batch operations.